### PR TITLE
Added fallback to English in Journal

### DIFF
--- a/journal/unix/journal.py
+++ b/journal/unix/journal.py
@@ -153,9 +153,16 @@ class Journal(QWidget):
 			self.close_label.hide()
 			self.close_button = False
 
-		if lang == 'en': img = os.path.join(base_path, 'images', '{}.png'.format(name))
-		else: img = os.path.join(base_path, 'images', lang.upper(), '{}.png'.format(name))
-		if not os.path.exists(img): return
+		img = img_en = os.path.join(base_path, 'images', '{}.png'.format(name))
+		if lang != 'en':
+			img = os.path.join(base_path, 'images', lang.upper(), '{}.png'.format(name))
+			if not os.path.exists(img):
+				print("No image {!r} for locale {!r}".format(name, lang), file=sys.stderr)
+				img = img_en
+
+		if not os.path.exists(img):
+			print("Image not found: {!r}".format(img), file=sys.stderr)
+			return
 
 		self.pixmap = QPixmap(img)
 		self.label.setPixmap(self.pixmap)


### PR DESCRIPTION
Previously it would just not change the image if Journal couldn't find an image file for some language. This fallback does exist on Windows version, but for some reason wasn't implemented for Unix one. I also added some messages to clearly tell what's happening and why it didn't use the locale that was specified in the message.

Issue happens only when playing in languages that are available in the game, but weren't added to the Journal (such as Russian) and only on Unix version of it (for Linux and Mac I guess).